### PR TITLE
Fix sample code in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,10 +31,12 @@ As stated in the specs, multibase encoded strings are prefixed with an identifie
 
 ## Usage
 ``` csharp
-var encoded = Multibase.Encode(MultibaseEncoding.Base32Lower, "hello world");
+using Multiformats.Base;
+using System.Text;
+
+string encoded = Multibase.Encode(MultibaseEncoding.Base32Lower, Encoding.UTF8.GetBytes("hello world"));
 // bnbswy3dpeb3w64tmmq
-var decoded = Multibase.Decode(encoded, out MultibaseEncoding encoding);
-// "hello world" (encoding: MultibaseEncoding.Base32Lower)
+byte[] decoded = Multibase.Decode(encoded, out MultibaseEncoding encoding);
 ```
 
 ## Supported base encodings

--- a/README.md
+++ b/README.md
@@ -21,7 +21,6 @@ As stated in the specs, multibase encoded strings are prefixed with an identifie
 - [Maintainers](#maintainers)
 - [Contribute](#contribute)
 - [License](#license)
-- [Third parties](#third-parties)
 
 ## Install
 


### PR DESCRIPTION
Multibase.Encode expects byte[], not string

Also include using directives and use explicit types instead of var.